### PR TITLE
moved reporters to src and release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.8
+
+* Added new config param to spec task - `reporters`. This allows developers to choose which reporters they want to use in the spec task.
+
 # 0.0.7
 
 * Fixes coverage bug introduced with `v0.0.6`.

--- a/lib/gulp/spec.js
+++ b/lib/gulp/spec.js
@@ -103,7 +103,7 @@ exports['default'] = function (opts) {
     var specs = opts.specs || '/src/***/**/__spec__.js';
     // an array of paths to ignore from coverage reports
     var ignoreCoverage = opts.ignoreCoverage || ['**/node_modules/**', '**/__spec__.js'];
-	// an array to specify what kind of reporters should karma generate
+    // an array to specify what kind of reporters should karma generate
     var reporters = opts.reporters || ['progress'];
     // which preprocessors the js files should run through
     var preProcessors = opts.preProcessors || ['eslint', 'babel', 'coverage', 'browserify'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "/lib",
   "scripts": {

--- a/src/gulp/spec.js
+++ b/src/gulp/spec.js
@@ -16,6 +16,7 @@
  *      preProcessors: [ 'babel', 'coverage', 'browserify' ],
  *      specPreProcessors: [ 'babel', 'browserify' ],
  *      ignoreCoverage: [ '/path/to/ignore' ],
+ *      reporters: ['progress'],
  *      coverage: {
  *        statements: 100,
  *        branches: 100,
@@ -74,6 +75,8 @@ export default function(opts) {
     var specs = opts.specs || '/src/***/**/__spec__.js';
     // an array of paths to ignore from coverage reports
     var ignoreCoverage = opts.ignoreCoverage || [ '**/node_modules/**', '**/__spec__.js' ];
+    // an array to specify what kind of reporters should karma generate
+    var reporters = opts.reporters || ['progress'];
     // which preprocessors the js files should run through
     var preProcessors = opts.preProcessors || [ 'eslint', 'babel', 'coverage', 'browserify' ];
     // which preprocessors the spec files should run through
@@ -134,7 +137,7 @@ export default function(opts) {
         ]
       },
       // what kind of reporters should karma generate
-      reporters: ['progress'],
+      reporters: reporters,
       // auto watch for any changes to rerun specs
       autoWatch: true,
       // only run the specs once


### PR DESCRIPTION
Moved the work completed by @gusch into the `/src` directory, ran the release script and bumped version to `v0.0.8`.
