### PR TITLE
Call some user defined function at each build...

### DIFF
--- a/src/gulp/build.js
+++ b/src/gulp/build.js
@@ -78,7 +78,9 @@ export default function (opts) {
         // if single build, or run and watch
         watch = (argv.build === undefined),
         // if in production mode
-        production = argv.production || false;
+        production = argv.production || false,
+        // callback function, called after single build or watch build
+        callback = opts.callback || null;
 
     if (opts.additionalSassTransformDirs) {
       // define directories in which to apply sass transforms
@@ -235,7 +237,7 @@ export default function (opts) {
       });
       gulp.src(fonts)
         .pipe(gulp.dest(fontDest));
-
+      opts.callback(true);
       // write the css file
       return gulp.src(cssFile)
         .on('error', () => gutil.log("*** Error writing the CSS File ***"))
@@ -252,7 +254,10 @@ export default function (opts) {
      * The main build task.
      */
     function build(f) {
-      if (f) gutil.log('Recompiling ' + f);
+      if (f) { 
+        gutil.log('Recompiling ' + f);
+        opts.callback(false);
+      }
       return bundler
         .bundle()
         .on('error', () => gutil.log("*** Browserify Error ***"))


### PR DESCRIPTION
...either it's first build, or watch build.

I couldn't find a way to do something like that:
`callback = opts.callback || function() { },`

`callback` is called with boolean parameter to know wether it's a first build or a watch build. Can't get it "piped" however.

User code sample:

```
gulp.task('build', BuildTask({
       src: './src/ssp-app/main.js',
       jsDest: './../../x/y/assets/javascripts',
       cssDest: './../../x/y/assets/stylesheets',
       fontDest: './../../x/y/assets/fonts',   

       callback: function(firstBuild){
           if (firstBuild) {                        
               gulp.src(['./a/b/c/**/*']).pipe(gulp.dest('./../../x/y/z'));
           }        
       }

   }));
```
