### PR TITLE
add additional testing options to task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.2.0
+
+## Enhancements
+
+### `gulp test` now takes additional optional flags
+
+* Run `gulp test --reportSlow` to identify tests taking more than 100ms.
+* Run `gulp test --debug` to run Karma in debug mode for additional info.
+
 # 0.1.1
 
 ## Bug Fixes
@@ -9,7 +18,7 @@
 * Upgrades most dependencies.
   * Easiest upgrade is to remove all local node_modules and reinstall fresh.
   * ESLint upgrade introduces more accurate ruling.
-* Updated path to spec_helper for spec task to remove warning 
+* Updated path to spec_helper for spec task to remove warning
 * Removes istanbul comments from compiled code.
 
 # 0.0.14

--- a/src/gulp/karma.conf.js
+++ b/src/gulp/karma.conf.js
@@ -1,6 +1,16 @@
 // Karma configuration
+import yargs from 'yargs';
+var argv = yargs.argv;
 
 module.exports = function(config) {
+    var logLevel = '';
+    // Set logger level for console output
+    if (argv.debug) {
+      logLevel = config.LOG_DEBUG
+    } else {
+      logLevel = config.LOG_INFO
+    }
+
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
@@ -27,7 +37,6 @@ module.exports = function(config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
+    logLevel: logLevel
   })
 }

--- a/src/gulp/spec.js
+++ b/src/gulp/spec.js
@@ -169,6 +169,11 @@ export default function(opts) {
       }
     }
 
+    // Report tests slower than value
+    if (argv.reportSlow) {
+      config.reportSlowerThan = 100;
+    }
+
     // tie the preprocessors to the relevant sources
     config.preprocessors[src] = preProcessors;
     config.preprocessors[specSrc] = specpreProcessors;


### PR DESCRIPTION
`gulp test` now takes additional optional flags
- Run `gulp test --reportSlow` to identify tests taking more than 100ms.
- Run `gulp test --debug` to run Karma in debug mode for additional info.
