### PR TITLE
Replace babel coverage plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,7 @@
   "env": {
     "test": {
       "auxiliaryCommentBefore": "istanbul ignore next",
-      "plugins": [ [ "__coverage__", { "ignore": ["**/*/__spec__.js", "**/node_modules/**"] } ] ]
+      "plugins": [ [ "istanbul", { "exclude": ["**/*/__spec__.js", "**/node_modules/**"] } ] ]
     },
     "development": {
       "plugins": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.5
+
+* Change package used for coverage reporting to babel-plugin-istanbul to allow `istanbul ignore`
+
 # 0.3.4
 
 * Adds option for `babelTransforms` for spec task.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-cli": "~6.14.0",
     "babel-eslint": "~6.1.2",
     "babel-istanbul": "~0.11.0",
-    "babel-plugin-__coverage__": "~11.0.0",
+    "babel-plugin-istanbul": "~4.1.3",
     "babel-plugin-react-transform": "~2.0.2",
     "babel-plugin-transform-class-properties": "~6.11.5",
     "babel-plugin-transform-object-rest-spread": "~6.8.0",


### PR DESCRIPTION
This plugin correctly interprets `istanbul ignore`statements and otherwise functions exactly as the __coverage__ plugin.