### PR TITLE
Adjust reference of karma-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "karma-chrome-launcher": "~2.0.0",
     "karma-coverage": "~1.1.1",
     "karma-es5-shim": "0.0.4",
-    "karma-eslint": "git@github.com:abramin/karma-eslint.git#report-error-tally",
+    "karma-eslint": "git://github.com/abramin/karma-eslint.git#report-error-tally",
     "karma-firefox-launcher": "~1.0.0",
     "karma-jasmine-ajax": "~0.1.13",
     "karma-jasmine": "~1.0.2",


### PR DESCRIPTION
Travis CI can't pull this in because it tries to use an SSH connection when npm installing and doesn't have a key to do so. Changing it to `git://` seems to resolve that.