### PR TITLE
Use `ssh` instead of `git` URLs in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next
+
+* Use `ssh` instead of `git://` URLs in `package.json`
+
 # 1.1.3
 
 * Bump .eslintrc max function params to 5

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "karma-chrome-launcher": "~2.0.0",
     "karma-coverage": "~1.1.1",
     "karma-es5-shim": "0.0.4",
-    "karma-eslint": "git://github.com/abramin/karma-eslint.git#report-error-tally",
+    "karma-eslint": "git@github.com:abramin/karma-eslint.git#report-error-tally",
     "karma-firefox-launcher": "~1.0.0",
     "karma-jasmine-ajax": "~0.1.13",
     "karma-jasmine": "~1.0.2",


### PR DESCRIPTION
The usage of `git://` URLs is often not possible because firewalls often block the `git` protocol. This can be prevented by using the `ssh` protocol instead.