### PR TITLE
Fix the ignoreCoverage option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,10 +8,6 @@
     "transform-class-properties"
   ],
   "env": {
-    "test": {
-      "auxiliaryCommentBefore": "istanbul ignore next",
-      "plugins": [ [ "istanbul", { "exclude": ["**/*/__spec__.js", "**/node_modules/**"] } ] ]
-    },
     "development": {
       "plugins": [
         ["react-transform", {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 1.1.5
+
+* Fixes an issue where the overriding the coverage ignore option was not being used during gulp.
+
 # 1.1.4
 
-* Update branch of karma-eslint package to fix build passing when errors present. 
+* Update branch of karma-eslint package to fix build passing when errors present.
 
 # 1.1.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "main": "/lib",
   "scripts": {

--- a/src/gulp/spec.js
+++ b/src/gulp/spec.js
@@ -128,7 +128,13 @@ export default function(opts) {
         specSrc = originPath + specs,
         babelOptions = {
           babelrc: false, // do not use babelrc files in gulp task
-          extends: originPath + '/node_modules/carbon-factory/.babelrc' // manually set babelrc for gulp task
+          extends: originPath + '/node_modules/carbon-factory/.babelrc', // manually set babelrc for gulp task
+          env: {
+            test: {
+              auxiliaryCommentBefore: "istanbul ignore next",
+              plugins: [ [ "istanbul", { exclude: ignoreCoverage } ] ]
+            }
+          }
         };
 
     if (babelTransforms.length) {
@@ -238,7 +244,6 @@ export default function(opts) {
       config.reporters.push('coverage');
       config.browserify.transform.push(
         istanbul({
-          // ignore these files from code coverage
           ignore: ignoreCoverage
         })
       );


### PR DESCRIPTION
This resolves the issue, where ignoreCoverage does not work when being passed used as an SpecTask option in the gulpfile.