### PR TITLE
Update package.json template to use carbon-react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.8
+
+* Update the `package.json` created when running `carbon app myapp` to use `carbon-react` and `carbon-factory` from npm, and to use the same version of common dependendencies as used in `carbon-react`.
+
 # 1.1.7
 
 * Configures 'no-use-before-define' to skip functions and classes.

--- a/src/tpl/package.txt
+++ b/src/tpl/package.txt
@@ -8,18 +8,18 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "carbon": "git+ssh://git@github.com/Sage/carbon.git",
-    "flux": "^2.1.1",
-    "history": "^1.12.5",
+    "carbon-react": "^1.0.0",
+    "flux": "~2.1.1",
+    "history": "~1.12.5",
     "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc8.tar.gz",
-    "immutable": "^3.7.5",
-    "react": "^0.14.0",
-    "react-addons-css-transition-group": "^0.14.0",
-    "react-dom": "^0.14.0",
-    "react-router": "^1.0.0"
+    "immutable": "~3.8.1",
+    "react": "~15.5.0",
+    "react-addons-css-transition-group": "~15.5.0",
+    "react-dom": "~15.5.0",
+    "react-router": "~2.8.0"
   },
   "devDependencies": {
-    "carbon-factory": "git+ssh://git@github.com/Sage/carbon-factory.git",
-    "gulp": "^3.9.0"
+    "carbon-factory": "^1.0.0",
+    "gulp": "~3.9.0"
   }
 }


### PR DESCRIPTION
Replace `carbon` with `carbon-react`, and install it from npm instead of GitHub.

Setup `carbon-factory` to install from npm too.

Update dependencies to match current versions in Carbon.