### PR TITLE
Update debugging Jest docs

### DIFF
--- a/docs/debugging-tests.md
+++ b/docs/debugging-tests.md
@@ -30,10 +30,11 @@ Unfortunately debugging tests in the browser via Node is not great, but they are
 {
   "type": "node",
   "request": "launch",
-  "name": "Run Tests",
+  "name": "Run Current Spec",
   "program": "${workspaceRoot}/node_modules/.bin/jest",
   "args": [
     "--runInBand",
+    "--config=./jest.conf.json"
     "${file}"
   ],
   "runtimeArgs": [
@@ -48,7 +49,7 @@ Unfortunately debugging tests in the browser via Node is not great, but they are
 ```
 
 * Save `launch.json`.
-* Run the debugger by pressing the play button at the top of the debugger panel.
+* Run the debugger by pressing the play button at the top of the debugger panel. This will debug the currently active file in the editor.
 
 ## Debugging in the Browser
 


### PR DESCRIPTION
Add `--config=./jest.conf.json` to the args passed to the test command.

Also update the name of the configuration, and add a note, to make it
clearer that this configuration debugs the currently active file in the
editor only.