### PR TITLE
applied envify transform across all node modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.1
+
+## Bug Fixes:
+
+* Envify now runs across all node modules.
+
 # 2.0.0
 
 * Jasmine and Karma have been replaced by Jest. See our [migration document for details](https://github.com/Sage/carbon-factory/blob/master/docs/migrating/v1-v2.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "main": "./jest.conf.json",
   "scripts": {

--- a/src/gulp/build.js
+++ b/src/gulp/build.js
@@ -164,7 +164,6 @@ export default function (opts) {
      * Envify options (sets env options when compiling code).
      */
     var envifyTransform = envify({
-      global: true,
       _: 'purge',
       NODE_ENV: process.env.NODE_ENV
     });
@@ -222,7 +221,7 @@ export default function (opts) {
 
     var browserified = browserify(browserifyOpts)
                        .transform("babelify", babelTransformOptions)
-                       .transform(envifyTransform);
+                       .transform(envifyTransform, { global: true });
 
     // create dirs for assets
     mkdirp(fontDest, function (err) {


### PR DESCRIPTION
The global param was in the wrong place, meaning that it wasn't being applied.

Can QA by running `gulp --build --production` in an application and seeing that any Logger warnings from Carbon are no longer output in the console.