### PR TITLE
enabled sourcemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+
+* Enabled sourcemaps when running in watch mode. Alternatively you can control if they are enabled/disabled with the `--sourcemaps` flag when running gulp.
+
 # 2.1.0
 
 * Updated Carbon CLI for setting up applications based on Carbon v2 and Carbon-Factory v2.

--- a/src/gulp/build.js
+++ b/src/gulp/build.js
@@ -88,7 +88,15 @@ export default function (opts) {
         // if uglify requested
         doUglify = (opts.uglify !== false),
         // array of modules to apply babel transforms to
-        babelTransforms = opts.babelTransforms || [];
+        babelTransforms = opts.babelTransforms || [],
+        // enable sourcemaps (enabled for watch mode by default)
+        sourcemaps = watch;
+
+    if (argv.sourcemaps === 'false') {
+      sourcemaps = false;
+    } else if (argv.sourcemaps) {
+      sourcemaps = true;
+    }
 
     if (opts.additionalSassTransformDirs) {
       // define directories in which to apply sass transforms
@@ -178,6 +186,8 @@ export default function (opts) {
       transform: [ aliasTransform ],
       // lookup paths when importing modules
       paths: [ './src', process.cwd() + '/node_modules' ],
+      // enable/disable sourcemaps
+      debug: sourcemaps,
 
       // Caching for watchify see:
       // https://github.com/substack/watchify/blob/v3.7.0/readme.markdown#watchifyb-opts


### PR DESCRIPTION
Enables sourcemaps by default when running in watch mode. Optionally can be enabled/disabled by passing `--sourcemaps` or `--sourcemaps=false` to gulp.

![screen shot 2017-11-06 at 15 40 08](https://user-images.githubusercontent.com/1668080/32497977-402aa78e-c3c6-11e7-83cd-f03f4ff8808a.png)
