### PR TITLE
removes node-inspector dependency for Node v8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+
+* Removes dependency `node-inspector`, allowing use of Node v8.
+
 # 2.1.0
 
 * Updated Carbon CLI for setting up applications based on Carbon v2 and Carbon-Factory v2.

--- a/docs/debugging-tests.md
+++ b/docs/debugging-tests.md
@@ -5,10 +5,27 @@ There are a number of ways to debug your code, please see the following links fo
 * https://facebook.github.io/jest/docs/troubleshooting.html
 * https://nodejs.org/en/docs/inspector/
 
-Unfortunately debugging tests in the browser via Node is not great, but they are working on it (we have some guides below on how to do this). Please refer to the following issues to learn more and keep track on progress:
+## Debugging in Browser with Node v8
 
-* https://github.com/facebook/jest/issues/1652
-* https://github.com/nodejs/node/issues/7593
+This will only work using Node v8 or higher.
+
+### Setup
+
+Add the following script to your `package.json` to make running the test easier in the future:
+
+```
+"scripts": {
+  "debug": "node --inspect ./node_modules/.bin/jest --watch --config=./jest.conf.json",
+}
+```
+
+### Running Tests
+
+You can now run the following command to run your tests:
+
+```
+npm run debug
+```
 
 ## Debugging in RubyMine
 
@@ -58,64 +75,3 @@ Unfortunately debugging tests in the browser via Node is not great, but they are
 * Save `launch.json`.
 * Focus on the __spec__ file by selecting it's tab.
 * Run the debugger by pressing the play button which will run the currently focused file.
-
-## Debugging in the Browser
-
-### Setup
-
-If you application has not yet been set up to debug, you will need to add the following scripts to your application's `package.json`:
-
-```
-"scripts": {
-  "debug:listen": "node --debug-brk ./node_modules/.bin/jest --runInBand --config=./jest.conf.json",
-  "debug:start": "node-inspector"
-}
-```
-
-### Debugging
-
-Add a `debugger;` statement to the test you’d like to debug
-
-In the terminal run the `debug:listen` script (you can also pass additional options such as the file we want to test):
-
-```bash
-npm run debug:listen relative/path/to/spec
-```
-
-In another terminal window/pane run:
-
-```
-npm run debug:start
-```
-
-This outputs a URL e.g. http://127.0.0.1:8080?port=5858
-
-Open the URL in Chrome. This will open the Chrome Developer Tools and a breakpoint will be set at the first line of the Jest CLI script.
-
-Hit the play button to continue running the test. The script should pause when it hits your debugger statement you placed in the code.
-
-## Debugging in the Terminal
-
-Debugging in the terminal can be a quick way to debug your tests.
-
-### Setup
-
-If you application has not yet been set up to debug, you will need to add the following scripts to your application's `package.json`:
-
-```
-"scripts": {
-  "debug:terminal": "node debug ./node_modules/.bin/jest --runInBand --config=./jest.conf.json"
-}
-```
-
-### Debugging
-
-Add a `debugger;` statement to the test you’d like to debug
-
-In the terminal run the `debug:terminal` script (you can also pass additional options such as the file we want to test):
-
-```bash
-npm run debug:terminal relative/path/to/spec
-```
-
-Once it boots, execute the character `c` to continue past the initial breakpoint. The code will then continue to execute until it reaches your breakpoint. To inspect and run commands execute `repl`, this will allow you to inspect your code as you like.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "abab": {
       "version": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
       "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
@@ -11,14 +19,6 @@
     "abbrev": {
       "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
       "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
-    },
-    "accepts": {
-      "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "requires": {
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-      }
     },
     "acorn": {
       "version": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
@@ -49,10 +49,6 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
-    },
-    "after": {
-      "version": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
       "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -103,7 +99,8 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "ansicolors": {
-      "version": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "any-promise": {
@@ -157,7 +154,7 @@
     },
     "arr-flatten": {
       "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-differ": {
       "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
@@ -178,10 +175,6 @@
     "array-find-index": {
       "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
-    "array-flatten": {
-      "version": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-map": {
       "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -925,7 +918,7 @@
     },
     "base64-js": {
       "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
     "bcrypt-pbkdf": {
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -938,26 +931,6 @@
     "beeper": {
       "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-    },
-    "biased-opener": {
-      "version": "https://registry.npmjs.org/biased-opener/-/biased-opener-0.2.8.tgz",
-      "integrity": "sha1-FZpJualxTB+xAvLg7RkG+rakUPQ=",
-      "requires": {
-        "browser-launcher2": "https://registry.npmjs.org/browser-launcher2/-/browser-launcher2-0.4.6.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "x-default-browser": "https://registry.npmjs.org/x-default-browser/-/x-default-browser-0.3.1.tgz"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
-    "big-integer": {
-      "version": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.23.tgz",
-      "integrity": "sha1-6F1QgiDHTj9DpM5y7tUfPaTblNE=",
-      "optional": true
     },
     "bin-version": {
       "version": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
@@ -1004,14 +977,6 @@
         "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
       }
     },
-    "bplist-parser": {
-      "version": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
-      "optional": true,
-      "requires": {
-        "big-integer": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.23.tgz"
-      }
-    },
     "brace-expansion": {
       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
@@ -1033,37 +998,13 @@
       "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
-    "browser-launcher2": {
-      "version": "https://registry.npmjs.org/browser-launcher2/-/browser-launcher2-0.4.6.tgz",
-      "integrity": "sha1-UVmECKE/TJxbIOukRVSywLCuQHQ=",
-      "requires": {
-        "headless": "https://registry.npmjs.org/headless/-/headless-0.1.7.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-        "plist": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-        "uid": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
-        "win-detect-browsers": "https://registry.npmjs.org/win-detect-browsers/-/win-detect-browsers-1.0.2.tgz"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        },
-        "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        }
-      }
-    },
     "browser-pack": {
       "version": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
         "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
         "umd": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
       }
@@ -1085,6 +1026,7 @@
       "version": "https://registry.npmjs.org/browserify/-/browserify-13.1.1.tgz",
       "integrity": "sha1-cqIxDi9wbth9uSnPDuc6Xhldm7A=",
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "assert": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
         "browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
         "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
@@ -1106,7 +1048,6 @@
         "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "labeled-stream-splicer": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
         "module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
         "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
@@ -1268,11 +1209,12 @@
       }
     },
     "cardinal": {
-      "version": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
       "requires": {
-        "ansicolors": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-        "redeyed": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz"
+        "ansicolors": "0.2.1",
+        "redeyed": "1.0.1"
       }
     },
     "caseless": {
@@ -1323,7 +1265,7 @@
     },
     "cipher-base": {
       "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
@@ -1331,7 +1273,7 @@
     },
     "circular-json": {
       "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY="
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
     },
     "cli-color": {
       "version": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
@@ -1362,18 +1304,20 @@
       }
     },
     "cli-table": {
-      "version": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "requires": {
-        "colors": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        "colors": "1.0.3"
       }
     },
     "cli-usage": {
-      "version": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
       "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
       "requires": {
-        "marked": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-        "marked-terminal": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz"
+        "marked": "0.3.6",
+        "marked-terminal": "1.7.0"
       }
     },
     "cli-width": {
@@ -1413,7 +1357,7 @@
     },
     "coffee-script": {
       "version": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM="
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
     "color-convert": {
       "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
@@ -1427,7 +1371,8 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combine-source-map": {
@@ -1525,14 +1470,6 @@
       "version": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
-    "content-disposition": {
-      "version": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-    },
-    "content-type": {
-      "version": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
-    },
     "content-type-parser": {
       "version": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
       "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
@@ -1540,14 +1477,6 @@
     "convert-source-map": {
       "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
-    },
-    "cookie": {
-      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
-    "cookie-signature": {
-      "version": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
       "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
@@ -1597,7 +1526,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
             "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
@@ -1618,7 +1547,7 @@
     },
     "crypto-browserify": {
       "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha1-lIlF78Z1ekANbl5a9HGU0QBkJ58=",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "requires": {
         "browserify-cipher": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
         "browserify-sign": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
@@ -1693,23 +1622,9 @@
       "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "deep-extend": {
-      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
     "deep-is": {
       "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "default-browser-id": {
-      "version": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-1.0.4.tgz",
-      "integrity": "sha1-5Z0JpdFXuCi4dsJoFuYcPSosIDo=",
-      "optional": true,
-      "requires": {
-        "bplist-parser": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "untildify": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
-      }
     },
     "default-require-extensions": {
       "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -1723,14 +1638,6 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
         "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-      }
-    },
-    "define-properties": {
-      "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
       }
     },
     "defined": {
@@ -1758,10 +1665,6 @@
       "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
-    "depd": {
-      "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
-    },
     "deprecated": {
       "version": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
@@ -1783,10 +1686,6 @@
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
       }
-    },
-    "destroy": {
-      "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
       "version": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
@@ -1886,10 +1785,6 @@
         "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
       }
     },
-    "ee-first": {
-      "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
     "elliptic": {
       "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
@@ -1902,10 +1797,6 @@
         "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
         "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
       }
-    },
-    "encodeurl": {
-      "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
       "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
@@ -1932,16 +1823,124 @@
       }
     },
     "enzyme-to-json": {
-      "version": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-1.5.1.tgz",
-      "integrity": "sha1-409NEmuz9Gls44ALUfntg99wh5k=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-1.6.0.tgz",
+      "integrity": "sha512-izMrbriQySEiWDUR0NeAyzCiRBncgDjfX5bt3xobkyUinEA79q8UuBNUfWFyjX2ahhP2G8k1GN4kG9NAUF405g==",
       "requires": {
-        "lodash.filter": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-        "lodash.isnil": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+        "lodash.filter": "4.6.0",
+        "lodash.isnil": "4.0.0",
         "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-        "lodash.omitby": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
-        "lodash.range": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-        "object-values": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
-        "object.entries": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz"
+        "lodash.omitby": "4.6.0",
+        "lodash.range": "3.2.0",
+        "object-values": "1.0.0",
+        "object.entries": "1.0.4"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+          "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+          "requires": {
+            "foreach": "2.0.5",
+            "object-keys": "1.0.11"
+          }
+        },
+        "es-abstract": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+          "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.1",
+            "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+          "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+          "requires": {
+            "is-callable": "1.1.3",
+            "is-date-object": "1.0.1",
+            "is-symbol": "1.0.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+          "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+          "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+          "requires": {
+            "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+          "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+        },
+        "lodash.filter": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+          "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+        },
+        "lodash.isnil": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+          "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+        },
+        "lodash.omitby": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+          "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
+        },
+        "lodash.range": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
+          "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0="
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+        },
+        "object-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
+          "integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU="
+        },
+        "object.entries": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+          "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+          "requires": {
+            "define-properties": "1.1.2",
+            "es-abstract": "1.9.0",
+            "function-bind": "1.1.1",
+            "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+          }
+        }
       }
     },
     "errno": {
@@ -1956,25 +1955,6 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
         "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-      }
-    },
-    "es-abstract": {
-      "version": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "requires": {
-        "es-to-primitive": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-      }
-    },
-    "es-to-primitive": {
-      "version": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "requires": {
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
       }
     },
     "es5-ext": {
@@ -2038,10 +2018,6 @@
         "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
         "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
       }
-    },
-    "escape-html": {
-      "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2140,7 +2116,7 @@
         },
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2176,7 +2152,7 @@
     },
     "eslint-import-resolver-node": {
       "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha1-RCJXTN5mqaewmZOO5NUIoZng48w=",
+      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "requires": {
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
         "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
@@ -2184,7 +2160,7 @@
     },
     "eslint-module-utils": {
       "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "requires": {
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
         "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
@@ -2192,7 +2168,7 @@
     },
     "eslint-plugin-import": {
       "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
-      "integrity": "sha1-Id4zOAue+1X1720uIQ7A4H5/pp8=",
+      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
       "requires": {
         "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
         "contains-path": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -2329,10 +2305,6 @@
       "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
-    "etag": {
-      "version": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
-    },
     "event-emitter": {
       "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
@@ -2382,49 +2354,6 @@
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
         "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-      }
-    },
-    "express": {
-      "version": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
-      "requires": {
-        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-        "array-flatten": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-        "content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-        "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-        "merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-        "proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-        "send": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-        "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          }
-        }
       }
     },
     "extend": {
@@ -2498,7 +2427,7 @@
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2519,28 +2448,6 @@
         "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
         "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
         "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-      }
-    },
-    "finalhandler": {
-      "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          }
-        }
       }
     },
     "find-index": {
@@ -2637,10 +2544,6 @@
         "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
       }
     },
-    "foreach": {
-      "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "forever-agent": {
       "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
@@ -2658,14 +2561,6 @@
         "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
       }
     },
-    "forwarded": {
-      "version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
-    },
-    "fresh": {
-      "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
-    },
     "fs-exists-sync": {
       "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
@@ -2680,7 +2575,7 @@
     },
     "fsevents": {
       "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "optional": true,
       "requires": {
         "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
@@ -3445,14 +3340,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3461,6 +3348,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3583,15 +3478,6 @@
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-      }
-    },
-    "fstream-ignore": {
-      "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "requires": {
-        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
       }
     },
     "function-bind": {
@@ -3768,7 +3654,7 @@
     },
     "globals": {
       "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
@@ -3784,7 +3670,7 @@
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4050,7 +3936,7 @@
     },
     "hash.js": {
       "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
@@ -4065,10 +3951,6 @@
         "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
         "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
       }
-    },
-    "headless": {
-      "version": "https://registry.npmjs.org/headless/-/headless-0.1.7.tgz",
-      "integrity": "sha1-bmL65miUf4gYTVwVbt58VpWn6cg="
     },
     "hmac-drbg": {
       "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4100,7 +3982,7 @@
     },
     "hosted-git-info": {
       "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-encoding-sniffer": {
       "version": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
@@ -4112,16 +3994,6 @@
     "htmlescape": {
       "version": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
-    },
-    "http-errors": {
-      "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "requires": {
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-      }
     },
     "http-signature": {
       "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -4213,10 +4085,10 @@
       "version": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
         "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
         "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -4237,10 +4109,6 @@
     "invert-kv": {
       "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
-    "ipaddr.js": {
-      "version": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
     },
     "is-absolute": {
       "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
@@ -4272,20 +4140,12 @@
         "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
       }
     },
-    "is-callable": {
-      "version": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
-    },
     "is-ci": {
       "version": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "requires": {
         "ci-info": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz"
       }
-    },
-    "is-date-object": {
-      "version": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-dotfile": {
       "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -4364,7 +4224,7 @@
     },
     "is-plain-object": {
       "version": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
       },
@@ -4387,13 +4247,6 @@
       "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
-    "is-regex": {
-      "version": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
-      }
-    },
     "is-relative": {
       "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
@@ -4407,10 +4260,6 @@
       "requires": {
         "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
       }
-    },
-    "is-symbol": {
-      "version": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4478,11 +4327,11 @@
     },
     "istanbul-lib-coverage": {
       "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo="
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
     },
     "istanbul-lib-hook": {
       "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-      "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+      "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
       "requires": {
         "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
       }
@@ -4508,7 +4357,7 @@
     },
     "istanbul-lib-report": {
       "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
+      "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
       "requires": {
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -4527,7 +4376,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-      "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+      "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
       "requires": {
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
@@ -4630,7 +4479,7 @@
         },
         "semver": {
           "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         },
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
@@ -4682,7 +4531,7 @@
         },
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5092,14 +4941,6 @@
       "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
-    "JSONStream": {
-      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "requires": {
-        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      }
-    },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
@@ -5261,15 +5102,18 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._arraycopy": {
-      "version": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
     },
     "lodash._arrayeach": {
-      "version": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
     },
     "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
         "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -5277,13 +5121,14 @@
       }
     },
     "lodash._baseclone": {
-      "version": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "requires": {
-        "lodash._arraycopy": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-        "lodash._arrayeach": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-        "lodash._basefor": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._baseassign": "3.2.0",
+        "lodash._basefor": "3.0.3",
         "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
         "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
       }
@@ -5293,7 +5138,8 @@
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basefor": {
-      "version": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
       "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
     },
     "lodash._basetostring": {
@@ -5305,7 +5151,8 @@
       "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
     },
     "lodash._bindcallback": {
-      "version": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
     },
     "lodash._getnative": {
@@ -5337,11 +5184,12 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.clonedeep": {
-      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "requires": {
-        "lodash._baseclone": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-        "lodash._bindcallback": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+        "lodash._baseclone": "3.3.0",
+        "lodash._bindcallback": "3.0.1"
       }
     },
     "lodash.cond": {
@@ -5355,10 +5203,6 @@
         "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
       }
     },
-    "lodash.filter": {
-      "version": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-    },
     "lodash.isarguments": {
       "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
@@ -5366,10 +5210,6 @@
     "lodash.isarray": {
       "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.isnil": {
-      "version": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
     },
     "lodash.isplainobject": {
       "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -5396,17 +5236,9 @@
       "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
     },
-    "lodash.omitby": {
-      "version": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
-      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
-    },
     "lodash.pickby": {
       "version": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
-    },
-    "lodash.range": {
-      "version": "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz",
-      "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0="
     },
     "lodash.restparam": {
       "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -5436,7 +5268,8 @@
       }
     },
     "lodash.toarray": {
-      "version": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
     "log-symbols": {
@@ -5503,22 +5336,25 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "marked": {
-      "version": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
       "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
     },
     "marked-terminal": {
-      "version": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
       "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
       "requires": {
-        "cardinal": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cli-table": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+        "cardinal": "1.0.0",
+        "chalk": "1.1.3",
+        "cli-table": "0.3.1",
         "lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-        "node-emoji": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz"
+        "node-emoji": "1.8.1"
       },
       "dependencies": {
         "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -5538,10 +5374,6 @@
         "crypt": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
         "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
       }
-    },
-    "media-typer": {
-      "version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memoizee": {
       "version": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
@@ -5618,20 +5450,12 @@
       "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
-    "merge-descriptors": {
-      "version": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
     "merge-stream": {
       "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
-    },
-    "methods": {
-      "version": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -5660,10 +5484,6 @@
         "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
       }
     },
-    "mime": {
-      "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
-    },
     "mime-db": {
       "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
       "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
@@ -5685,7 +5505,7 @@
     },
     "minimatch": {
       "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
       }
@@ -5705,6 +5525,7 @@
       "version": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
         "cached-path-relative": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
@@ -5712,7 +5533,6 @@
         "detective": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
         "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
         "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
@@ -5783,19 +5603,16 @@
       "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
-    "negotiator": {
-      "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
     "next-tick": {
       "version": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
       "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
     },
     "node-emoji": {
-      "version": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha1-buxr+wdCHiFIx1xrunJCH4UwqCY=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "requires": {
-        "lodash.toarray": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz"
+        "lodash.toarray": "4.4.0"
       }
     },
     "node-gyp": {
@@ -5819,7 +5636,7 @@
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5842,104 +5659,46 @@
         }
       }
     },
-    "node-inspector": {
-      "version": "https://registry.npmjs.org/node-inspector/-/node-inspector-1.1.1.tgz",
-      "integrity": "sha1-54UeuXPzgFQ8BY21ZKmBIFXqxkA=",
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-        "biased-opener": "https://registry.npmjs.org/biased-opener/-/biased-opener-0.2.8.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "express": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-        "serve-favicon": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz",
-        "strong-data-uri": "https://registry.npmjs.org/strong-data-uri/-/strong-data-uri-1.0.4.tgz",
-        "v8-debug": "https://registry.npmjs.org/v8-debug/-/v8-debug-1.0.1.tgz",
-        "v8-profiler": "https://registry.npmjs.org/v8-profiler/-/v8-profiler-5.7.0.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
-      },
-      "dependencies": {
-        "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "cliui": {
-          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-          }
-        },
-        "window-size": {
-          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-        },
-        "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-          }
-        }
-      }
-    },
     "node-int64": {
       "version": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-notifier": {
-      "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
       "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
       "requires": {
-        "cli-usage": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
+        "cli-usage": "0.1.4",
         "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-        "lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-        "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+        "lodash.clonedeep": "3.0.2",
+        "minimist": "1.2.0",
+        "semver": "5.4.1",
+        "shellwords": "0.1.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
-        }
-      }
-    },
-    "node-pre-gyp": {
-      "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-      "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
-      "requires": {
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-        "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-        "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        },
+        "shellwords": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+          "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+        },
+        "which": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "requires": {
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+          }
         }
       }
     },
@@ -5974,7 +5733,7 @@
         },
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5999,17 +5758,9 @@
         }
       }
     },
-    "nopt": {
-      "version": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "requires": {
-        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
-      }
-    },
     "normalize-package-data": {
       "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
         "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
         "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -6026,7 +5777,7 @@
     },
     "npmlog": {
       "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
         "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
         "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -6054,14 +5805,6 @@
       "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-    },
-    "object-values": {
-      "version": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
-      "integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU="
-    },
     "object.defaults": {
       "version": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
@@ -6085,16 +5828,6 @@
         }
       }
     },
-    "object.entries": {
-      "version": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
-      }
-    },
     "object.omit": {
       "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
@@ -6115,13 +5848,6 @@
       "integrity": "sha1-kI8018VkUOeghdjWWuo4sqL1aVQ=",
       "requires": {
         "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
-    },
-    "on-finished": {
-      "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
       }
     },
     "once": {
@@ -6428,10 +6154,6 @@
       "version": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
     },
-    "parseurl": {
-      "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
-    },
     "path-browserify": {
       "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
@@ -6466,10 +6188,6 @@
     "path-root-regex": {
       "version": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
-    },
-    "path-to-regexp": {
-      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -6525,22 +6243,6 @@
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
       }
     },
-    "plist": {
-      "version": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
-      "integrity": "sha1-CEtQk93JJQbiWfh0uNmxr7jHlZM=",
-      "requires": {
-        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-        "xmlbuilder": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-        "xmldom": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
-        }
-      }
-    },
     "pluralize": {
       "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
@@ -6563,7 +6265,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
           }
@@ -6595,14 +6297,6 @@
       "integrity": "sha1-IXZDvWYS1Y9LtU/n5rRmQoYHPN8=",
       "requires": {
         "read": "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
-      }
-    },
-    "proxy-addr": {
-      "version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
-      "requires": {
-        "forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-        "ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz"
       }
     },
     "prr": {
@@ -6646,7 +6340,7 @@
     },
     "randomatic": {
       "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
         "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
         "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
@@ -6679,29 +6373,9 @@
     },
     "randombytes": {
       "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "requires": {
         "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-      }
-    },
-    "range-parser": {
-      "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "rc": {
-      "version": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "requires": {
-        "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "react-deep-force-update": {
@@ -6749,7 +6423,7 @@
     },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -6811,14 +6485,16 @@
       }
     },
     "redeyed": {
-      "version": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "requires": {
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz"
+        "esprima": "3.0.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
           "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
         }
       }
@@ -7017,7 +6693,7 @@
     },
     "safe-buffer": {
       "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
@@ -7085,7 +6761,7 @@
         },
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7118,7 +6794,7 @@
     },
     "sax": {
       "version": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scss-tokenizer": {
       "version": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -7154,68 +6830,13 @@
       "dependencies": {
         "semver": {
           "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
-        }
-      }
-    },
-    "send": {
-      "version": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          }
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         }
       }
     },
     "sequencify": {
       "version": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
-    },
-    "serve-favicon": {
-      "version": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.3.tgz",
-      "integrity": "sha1-WYaxewUCZCtkHCH4GLGszjICXSM=",
-      "requires": {
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-        }
-      }
-    },
-    "serve-static": {
-      "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-      "requires": {
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-        "send": "https://registry.npmjs.org/send/-/send-0.15.3.tgz"
-      }
     },
     "set-blocking": {
       "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -7224,10 +6845,6 @@
     "set-immediate-shim": {
       "version": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
-    "setprototypeof": {
-      "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sha.js": {
       "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
@@ -7278,7 +6895,7 @@
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7371,10 +6988,6 @@
         }
       }
     },
-    "statuses": {
-      "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
     "stream-browserify": {
       "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
@@ -7405,7 +7018,7 @@
     },
     "stream-http": {
       "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "requires": {
         "builtin-status-codes": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -7430,13 +7043,6 @@
       "version": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
       "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-      }
-    },
     "string-length": {
       "version": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
@@ -7451,6 +7057,13 @@
         "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "stringstream": {
@@ -7481,13 +7094,6 @@
     "strip-json-comments": {
       "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "strong-data-uri": {
-      "version": "https://registry.npmjs.org/strong-data-uri/-/strong-data-uri-1.0.4.tgz",
-      "integrity": "sha1-E2dl66+OD0rWDEsUZ3nwYsKdGPA=",
-      "requires": {
-        "truncate": "https://registry.npmjs.org/truncate/-/truncate-1.0.5.tgz"
-      }
     },
     "subarg": {
       "version": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
@@ -7545,7 +7151,7 @@
         },
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
@@ -7569,20 +7175,6 @@
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
-    "tar-pack": {
-      "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-        "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-        "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-      }
-    },
     "ternary-stream": {
       "version": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
@@ -7595,7 +7187,7 @@
     },
     "test-exclude": {
       "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-      "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+      "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "requires": {
         "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
         "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -7610,7 +7202,7 @@
     },
     "throat": {
       "version": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha1-UMsGcO28QCN7njR9fh+I5GIK+DY="
+      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
     },
     "through": {
       "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7691,10 +7283,6 @@
       "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
-    "truncate": {
-      "version": "https://registry.npmjs.org/truncate/-/truncate-1.0.5.tgz",
-      "integrity": "sha1-xjbGwfUO7XySevBsHb/6tTx6vig="
-    },
     "tryit": {
       "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
@@ -7710,20 +7298,22 @@
       }
     },
     "tsify": {
-      "version": "https://registry.npmjs.org/tsify/-/tsify-3.0.1.tgz",
-      "integrity": "sha1-I1Cf87TnEQypZW9sJ8oT7IVgVvY=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tsify/-/tsify-3.0.3.tgz",
+      "integrity": "sha1-oDLhpqccJiHD8lwEFUWdU7cLnsA=",
       "requires": {
         "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
         "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+        "semver": "5.4.1",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
         "tsconfig": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.3.tgz"
       },
       "dependencies": {
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         }
       }
     },
@@ -7748,14 +7338,6 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
         "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-      }
-    },
-    "type-is": {
-      "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "requires": {
-        "media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
       }
     },
     "typedarray": {
@@ -7796,14 +7378,6 @@
       "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
     },
-    "uid": {
-      "version": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
-      "integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM="
-    },
-    "uid-number": {
-      "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-    },
     "ultron": {
       "version": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
@@ -7823,18 +7397,6 @@
     "unique-stream": {
       "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
-    },
-    "unpipe": {
-      "version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "untildify": {
-      "version": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "optional": true,
-      "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-      }
     },
     "url": {
       "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -7871,29 +7433,9 @@
       "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "utils-merge": {
-      "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
-    },
     "uuid": {
       "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
-    },
-    "v8-debug": {
-      "version": "https://registry.npmjs.org/v8-debug/-/v8-debug-1.0.1.tgz",
-      "integrity": "sha1-auHG2uRHe7PO15tSPk0WDB2GZ/4=",
-      "requires": {
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-        "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
-      }
-    },
-    "v8-profiler": {
-      "version": "https://registry.npmjs.org/v8-profiler/-/v8-profiler-5.7.0.tgz",
-      "integrity": "sha1-6DgcvrtbX9DKjSsJ9qAYGhWNs00=",
-      "requires": {
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-        "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
-      }
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "v8flags": {
       "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
@@ -7909,10 +7451,6 @@
         "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
         "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
       }
-    },
-    "vary": {
-      "version": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
     },
     "verror": {
       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
@@ -8129,26 +7667,9 @@
     },
     "wide-align": {
       "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
         "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-      }
-    },
-    "win-detect-browsers": {
-      "version": "https://registry.npmjs.org/win-detect-browsers/-/win-detect-browsers-1.0.2.tgz",
-      "integrity": "sha1-9F8Q0UEIbF2UrhTAOyCYRAp+cbA=",
-      "requires": {
-        "after": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-          "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo="
-        }
       }
     },
     "window-size": {
@@ -8194,33 +7715,9 @@
         "ultron": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
       }
     },
-    "x-default-browser": {
-      "version": "https://registry.npmjs.org/x-default-browser/-/x-default-browser-0.3.1.tgz",
-      "integrity": "sha1-f2GUFU/ReGzyYeaLVIjEcSegSXc=",
-      "requires": {
-        "default-browser-id": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-1.0.4.tgz"
-      }
-    },
     "xml-name-validator": {
       "version": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
-    },
-    "xmlbuilder": {
-      "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
-      "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
-      "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
-    },
-    "xmldom": {
-      "version": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xtend": {
       "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "jest-cli": "^20.0.4",
     "livereactload": "~3.1.1",
     "mkdirp": "~0.5.1",
-    "node-inspector": "^1.1.1",
     "node-notifier": "~4.6.1",
     "parcelify": "~2.1.0",
     "promptly": "~2.1.0",


### PR DESCRIPTION
`node-inspector` is not required or supported in Node 8 - so remove it 💥 