### PR TITLE
added import hoisting for css files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+Hoists `@import` CSS rules to the top of the CSS file.
+
 # 4.0.0
 
 Updated versions of packages. Please [see commit](https://github.com/Sage/carbon-factory/commit/8afe6ef2f23b4fdea33daf2b10211e5c63f9912f) for all changes. Build tasks should still work, however some tests may need updating.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4960,6 +4960,15 @@
         "fancy-log": "1.3.2",
         "plugin-error": "1.0.1",
         "stream-to-array": "2.3.0",
+        "through2": "2.0.3"
+      }
+    },
+    "gulp-hoist-css-imports": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-hoist-css-imports/-/gulp-hoist-css-imports-1.0.2.tgz",
+      "integrity": "sha1-Q+UTNDjhluoIDa46/7ImktMxrAA=",
+      "requires": {
+        "gulp-util": "3.0.8",
         "through2": "2.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "main": "./jest.conf.json",
   "scripts": {
@@ -44,6 +44,7 @@
     "gulp-css-replace-url": "^0.2.4",
     "gulp-eslint": "4.0.2",
     "gulp-gzip": "1.4.2",
+    "gulp-hoist-css-imports": "^1.0.2",
     "gulp-if": "2.0.2",
     "gulp-streamify": "1.0.2",
     "gulp-uglify": "2.1.2",

--- a/src/gulp/build.js
+++ b/src/gulp/build.js
@@ -54,6 +54,7 @@ import uglify from 'gulp-uglify';
 import urlAdjuster from 'gulp-css-replace-url';
 import cleanCSS from 'gulp-clean-css';
 import gulpGzip from 'gulp-gzip';
+import gulpHoist from 'gulp-hoist-css-imports';
 import streamify from 'gulp-streamify';
 import livereactload from 'livereactload';
 import { Spinner } from 'cli-spinner';
@@ -315,6 +316,7 @@ export default function (opts) {
       // write the css file
       return gulp.src(cssDest + '/' + cssFile)
         .pipe(gulpif(!!assetsUrl, urlAdjuster({ prepend: assetsUrl })))
+        .pipe(gulpHoist())
         .pipe(cleanCSS())
         .pipe(gulpif(production && gzip, gulpGzip({ append: false })))
         .pipe(gulp.dest(cssDest));


### PR DESCRIPTION
Ensures that `@import` rules are at the top of the file, otherwise they do not work.

Currently our app is not loading a custom font, this should resolve the issue.