### PR TITLE
AC-3044 fix image gzip bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.1
+
+## Webpack Fix
+
+We no longer gzip images as part of the production build.
+
 # 4.1.0
 
 ## Webpack Support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "main": "./jest.conf.json",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -179,7 +179,7 @@ module.exports = function(opts) {
       config.plugins.push(
         new CompressionPlugin({
           asset: '[path][query]',
-          test: new RegExp(`^[^.]+$|\.(?!(${imageFormats})$)([^.]+$)`, 'i'),
+          exclude: new RegExp(`\.(${imageFormats})$`, 'i'),
           minRatio: Infinity
         })
       );


### PR DESCRIPTION
We should not be gzipping image files, however the regex was wrong on the previous version. This change resolves it so images are no longer gzipped.