### PR TITLE
Generate Source Maps in Development Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.2.0
+
+## Add Sourcemaps in Development Mode
+
+We now generate sourcemaps when running in development mode.
+
 # 5.1.0
 
 ## Bundle Stats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "scripts": {},
   "author": "The Sage Group plc",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,11 @@ module.exports = function(opts) {
     }
   };
 
+  // Enable sourcemaps as long as we're not in production mode
+  if (!production) {
+    config.devtool = 'eval-source-maps';
+  }
+
   /***********
    * LOADERS *
    ***********/


### PR DESCRIPTION
Add config to webpack to generate source maps when running in development mode.