### PR TITLE
Fix version mismatch in package-lock.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.2.1
+
+## Bug Fixes
+
+Bump the version number in `package-lock.json`.
+
 # 5.2.0
 
 ## Add Sourcemaps in Development Mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "5.1.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "scripts": {},
   "author": "The Sage Group plc",


### PR DESCRIPTION
The version numbers in `package.json` and `package-lock.json` were out jof sync.

This bumps the version to `v5.2.1` in both.