### PR TITLE
Remove uglify-webpack-plugin as webpack uses it by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.3.0
+
+## webpack
+
+Remove the `uglify-webpack-plugin` that we used in production builds. webpack uses this by default for production builds, and with the same options we used, so we don't need to include it here.
+
 # 5.2.1
 
 ## Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "parcelify-loader": "2.0.0",
     "sass-loader": "7.0.3",
     "style-loader": "0.21.0",
-    "uglifyjs-webpack-plugin": "1.2.7",
     "webpack": "4.16.1",
     "webpack-bundle-analyzer": "2.13.1",
     "webpack-cli": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "scripts": {},
   "author": "The Sage Group plc",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const CompressionPlugin = require("compression-webpack-plugin")
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
@@ -174,10 +173,6 @@ module.exports = function(opts) {
     // Production Plugins
     config.plugins = [
       clean,
-      new UglifyJsPlugin({
-        cache: true,
-        parallel: true
-      }),
       new OptimizeCSSAssetsPlugin({
         cssProcessorOptions: {
           safe: true


### PR DESCRIPTION
For production builds webpack uses the uglify-webpack-plugin: https://webpack.js.org/guides/production/#minification

It also [uses the same options](https://github.com/webpack/webpack/blob/master/lib/WebpackOptionsDefaulter.js#L308) that we used. Therefore we don't need to include it here.

Also, when it _was_ included here it seemed to interfere with the generation of source map files.