### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
     }],
     'jsx-a11y/anchor-is-valid': 'warn',
     'jsx-a11y/click-events-have-key-events': 'warn',
-    'jsx-a11y/label-has-for': 'warn',
+    'jsx-a11y/label-has-associated-control': 'warn',
     'jsx-a11y/mouse-events-have-key-events': 'warn',
     'jsx-a11y/no-noninteractive-element-interactions': 'warn',
     'jsx-a11y/no-static-element-interactions': 'warn',


### PR DESCRIPTION
* `label-has-for` is depreciated, but it looks like `label-has-associated-control` is the correct replacement
* https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
* https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md