### PR TITLE
FE-1098 turn on tree-shaking and add plugins to tree-shake lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,7 @@
   "plugins": [
     "transform-object-rest-spread",
     "transform-class-properties",
-    "lodash"
+    "lodash",
     "syntax-dynamic-import"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
   ],
   "plugins": [
     "transform-object-rest-spread",
-    "transform-class-properties"
+    "transform-class-properties",
+    "lodash"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Added support to the webpack config to enable code splitting. See the [React docs](https://reactjs.org/docs/code-splitting.html) for more information.
 * Enabled source maps for production, these will get generated as an external file with the extension `.js.map`.
-* Enabled tree-shaking, see webpack docs [https://webpack.js.org/guides/tree-shaking/].
+* Enabled tree-shaking, see [webpack docs](https://webpack.js.org/guides/tree-shaking/).
 * Added plugins to apply tree-shaking to lodash.
 
 # 6.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Added support to the webpack config to enable code splitting. See the [React docs](https://reactjs.org/docs/code-splitting.html) for more information.
 * Enabled source maps for production, these will get generated as an external file with the extension `.js.map`.
+* Enabled tree-shaking, see webpack docs [https://webpack.js.org/guides/tree-shaking/].
+* Added plugins to apply tree-shaking to lodash.
 
 # 6.1.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,31 @@
         "@babel/types": "7.0.0-beta.44"
       }
     },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+          "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
@@ -1148,6 +1173,35 @@
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc="
+    },
+    "babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+          "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -7247,6 +7301,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
+    "lodash-webpack-plugin": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz",
+      "integrity": "sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -10019,6 +10081,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
     },
     "require-uncached": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "type": "git",
     "url": "https://github.com/Sage/carbon-factory"
   },
+  "sideEffects": false,
   "dependencies": {
     "babel-cli": "6.26.0",
     "babel-core": "6.26.3",
     "babel-eslint": "8.2.6",
     "babel-jest": "23.4.0",
     "babel-loader": "7.1.5",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-preset-env": "1.7.0",
@@ -32,6 +34,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "23.4.1",
     "jest-cli": "23.4.1",
+    "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "0.4.1",
     "node-sass": "4.9.2",
     "optimize-css-assets-webpack-plugin": "4.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const CompressionPlugin = require("compression-webpack-plugin")
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const path = process.cwd();
@@ -65,7 +66,7 @@ module.exports = function(opts) {
     use: {
       loader: 'babel-loader',
       options: {
-        presets: ['env'],
+        presets: [['env', { modules: false }]],
         plugins: [
           'transform-class-properties',
           'transform-object-rest-spread'
@@ -168,7 +169,8 @@ module.exports = function(opts) {
       }),
       new MiniCssExtractPlugin({
         filename: 'stylesheets/ui.css'
-      })
+      }),
+      new LodashModuleReplacementPlugin
     ]
 
     if (gzip) {


### PR DESCRIPTION
Makes changes to configuration in order to take advantage of tree-shaking with webpack. 

Adds `babel-plugin-lodash` and `lodash-webpack-plugin` which combined allow lodash to benefit from tree-shaking. 