### PR TITLE
added config for prod sourcemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 6.2.0
 
 * Added support to the webpack config to enable code splitting. See the [React docs](https://reactjs.org/docs/code-splitting.html) for more information.
-* Enabled source maps for production, these will get generated as an external file with the extension `.js.map`.
+* Enabled source maps for production, these will get generated as an external file with the extension `.js.map`. To enable these turn them on with `productionSourcemaps: true` in the webpack config. Please note that you should only enable these if you can ensure they're not publicly accessible.
 
 # 6.1.1
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = function(opts) {
   const singlePageApp = opts.singlePageApp || false;
   const showStats = process.argv.includes('--stats');
   const statsOptions = opts.statsOptions;
+  const productionSourcemaps = opts.productionSourcemaps || false;
 
   /******************
    * WEBPACK CONFIG *
@@ -51,7 +52,8 @@ module.exports = function(opts) {
   };
 
   // Enable sourcemaps, different kinds depending on environment
-  config.devtool = production ? 'source-map' : 'eval-source-maps';
+  if (production && productionSourcemaps) config.devtool = 'source-map'
+  if (!production) config.devtool = 'eval-source-maps';
 
   /***********
    * LOADERS *


### PR DESCRIPTION
Put the sourcemaps for production behind config, so they can be turned on once the correct restrictions have been applied to the CDN.