### PR TITLE
Replace relative path with absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.0
+
+Change relative path to absolute path in `webpack.config.js` to fix build issue on demo site
+
 # 8.2.0
 
 The `package-lock.json` was updated to fix vulnerability in `handlebars`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "scripts": {},
   "author": "The Sage Group plc",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = function(opts) {
     resolve: {
       modules: lookupPaths.concat([
         _p.resolve(path, './src'),
-        _p.resolve(path, './node_modules')
+        'node_modules'
       ]),
       extensions: ['.wasm', '.mjs', '.js', '.json', '.ts', '.tsx']
     }


### PR DESCRIPTION
It allows webpack scans `node_modules` and its ancestors.
It will fix a problem related to demo site which is breaking build with a new version of React-Transition-Group