### PR TITLE
FE-2501 broken build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 11.0.1
+
+## Webpack
+
+Update to `webpack.config.js` to replace `asset` option with `filename` option.
+
 # 11.0.0
 
 `compression-webpack-plugin` (`v3.0.1`) and `webpack` (`4.41.2`) upgraded to fix vulnerability in `serialize-javascript`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-factory",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Tools to help create user interfaces with Carbon and React.",
   "scripts": {},
   "author": "The Sage Group plc",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -191,7 +191,7 @@ module.exports = function(opts) {
     if (gzip) {
       config.plugins.push(
         new CompressionPlugin({
-          asset: '[path][query]',
+          filename: '[path][query]',
           exclude: new RegExp(`\.(${imageFormats})$`, 'i'),
           minRatio: Infinity
         })


### PR DESCRIPTION
### Description
This PR fixes v11.0.0 by replacing the `asset` object with a `filename` object in `webpack.config.js` as per the release notes for `compression-webpack-plugin` v2.0.0.
https://github.com/webpack-contrib/compression-webpack-plugin/releases/tag/v2.0.0

Currently v11.0.0 causes broken builds because the `asset` object is no longer part of the `compression-webpack-plugin` API.

### Checklist
<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] CHANGELOG.md update
- [x] Package.json version bump

### Additional context
N/A

### Testing instructions
You need to prepare a clean file system to test that the new files are installed and that any previous build is discarded.
1. I've built a test branch of Carbon that includes this branch of carbon-factory, it's available here: `FE-2501-test-branch`
2. Check it out and ensure your `deploy/` directory only has files from the repo, Ie. `index.html`, `favicon.ico` & `images/` directory
3. `$ npm install`
4. `$ npm run-script build`

This should build and populate `deploy/assets/` `deploy/docs/` and `deploy/storybook/` and not throw any Errors.
